### PR TITLE
🔑 Fix key links

### DIFF
--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -19,7 +19,7 @@
 </ul>
 <h2>Other Things:</h2>
 <ul>
-  <li><a href="jacobwoffenden-gpg.asc" class="touch-target">GPG key</a></li>
-  <li><a href="content/ssh/jacobwoffenden-ssh.pub" class="touch-target">SSH key</a></li>
+  <li><a href="/keys/gpg/jacobwoffenden-gpg.asc" class="touch-target">GPG key</a></li>
+  <li><a href="/keys//ssh/jacobwoffenden-ssh.pub" class="touch-target">SSH key</a></li>
 </ul>
 {% endblock content %}


### PR DESCRIPTION
This pull request includes a small change to the `site/templates/index.html` file. The change updates the URLs for the GPG and SSH keys to use a new directory structure.

* [`site/templates/index.html`](diffhunk://#diff-0f4cb1d6d47519a13c8f61d5b48c12baca1987f0358104f1f8bcbac5ce97a50cL22-R23): Updated the URLs for the GPG and SSH keys to `/keys/gpg/jacobwoffenden-gpg.asc` and `/keys/ssh/jacobwoffenden-ssh.pub`, respectively.

Signed-off-by: Jacob Woffenden <jacob@woffenden.io> 